### PR TITLE
feat: Add clean namespace option to manual deployment workflow

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -13,6 +13,11 @@ on:
         required: true
         default: 'all'
         type: string
+      clean_namespace:
+        description: 'Clean namespace before deployment (delete and recreate)'
+        required: false
+        default: false
+        type: boolean
       reason:
         description: 'Reason for manual deployment'
         required: false
@@ -65,6 +70,7 @@ jobs:
           echo "========================================="
           echo "Version: ${VERSION}"
           echo "Apps: ${DEPLOY_APPS}"
+          echo "Clean Namespace: ${{ inputs.clean_namespace }}"
           echo "Reason: ${{ inputs.reason || 'Not specified' }}"
           echo "Triggered by: ${{ github.actor }}"
           echo "========================================="
@@ -83,6 +89,21 @@ jobs:
 
       - name: Setup Kubernetes environment
         run: bash .github/scripts/setup-k8s.sh
+
+      # Clean namespace if requested (fresh start)
+      - name: Clean namespace
+        if: inputs.clean_namespace == true
+        run: |
+          echo "🧹 Cleaning namespace ${K8S_NAMESPACE} for fresh deployment..."
+          if kubectl get namespace ${K8S_NAMESPACE} &> /dev/null; then
+            echo "Deleting existing namespace..."
+            kubectl delete namespace ${K8S_NAMESPACE}
+            echo "Waiting for namespace deletion to complete..."
+            kubectl wait --for=delete namespace/${K8S_NAMESPACE} --timeout=60s || true
+          fi
+          echo "Creating fresh namespace..."
+          kubectl create namespace ${K8S_NAMESPACE}
+          echo "✅ Namespace ready for deployment"
 
       # Deploy infrastructure components
       - name: Deploy infrastructure components


### PR DESCRIPTION
* Introduced a new input parameter `clean_namespace` to the manual deployment workflow, allowing users to delete and recreate the Kubernetes namespace before deployment.
* Added a job step to handle the cleaning of the namespace if the parameter is set to true, ensuring a fresh deployment environment.

## Summary
Brief description of changes

## Type of Change
- [x] `feat:` New feature (minor version bump)
- [ ] `fix:` Bug fix (patch version bump)
- [ ] `docs:` Documentation (patch version bump)
- [ ] `refactor:` Code refactor (patch version bump)
- [ ] `test:` Tests (patch version bump)
- [ ] `chore:` Maintenance (patch version bump)
- [ ] `ci:` CI/CD changes (patch version bump)
- [ ] `perf:` Performance improvements (patch version bump)
- [ ] `style:` Code style (patch version bump)
- [ ] Breaking change (add `!` or `BREAKING CHANGE:` for major version bump)

## ⚠️ Important: PR Title Format
Make sure your PR title follows conventional commits format:
- ✅ `feat: add user authentication`
- ✅ `fix: resolve memory leak in parser`
- ✅ `feat!: remove support for Node 12` (breaking change)
- ❌ `update code` (wrong format)

**For breaking changes**, use one of these formats:
- Add `!` after type: `feat!: breaking change description`
- Or add `BREAKING CHANGE:` in PR description body

**This PR title will be used as the squash merge commit message!**

## Test Plan
- [ ] Tests pass
- [ ] Manual testing completed