### PR TITLE
chore: update resource limits and service type in Helm values

### DIFF
--- a/apps/backend/helm/values.yaml
+++ b/apps/backend/helm/values.yaml
@@ -3,8 +3,8 @@ service:
 
 resources:
   requests:
-    memory: "128Mi"
+    memory: "64Mi"
     cpu: "100m"
   limits:
-    memory: "256Mi"
+    memory: "128Mi"
     cpu: "200m"

--- a/apps/frontend/helm/values.yaml
+++ b/apps/frontend/helm/values.yaml
@@ -1,8 +1,7 @@
 service:
-  type: NodePort
+  type: ClusterIP
   port: 80
   targetPort: 3000
-  nodePort: 30300
 
 resources:
   requests:


### PR DESCRIPTION
- Reduced memory requests from 128Mi to 64Mi and limits from 256Mi to 128Mi in backend values.yaml.
- Changed service type from NodePort to ClusterIP in frontend values.yaml.

## Summary
Brief description of changes

## Type of Change
- [ ] `feat:` New feature (minor version bump)
- [ ] `fix:` Bug fix (patch version bump)
- [ ] `docs:` Documentation (patch version bump)
- [ ] `refactor:` Code refactor (patch version bump)
- [ ] `test:` Tests (patch version bump)
- [x] `chore:` Maintenance (patch version bump)
- [ ] `ci:` CI/CD changes (patch version bump)
- [ ] `perf:` Performance improvements (patch version bump)
- [ ] `style:` Code style (patch version bump)
- [ ] Breaking change (add `!` or `BREAKING CHANGE:` for major version bump)

## ⚠️ Important: PR Title Format
Make sure your PR title follows conventional commits format:
- ✅ `feat: add user authentication`
- ✅ `fix: resolve memory leak in parser`
- ✅ `feat!: remove support for Node 12` (breaking change)
- ❌ `update code` (wrong format)

**For breaking changes**, use one of these formats:
- Add `!` after type: `feat!: breaking change description`
- Or add `BREAKING CHANGE:` in PR description body

**This PR title will be used as the squash merge commit message!**

## Test Plan
- [ ] Tests pass
- [ ] Manual testing completed